### PR TITLE
Issue 1

### DIFF
--- a/build/unity.src
+++ b/build/unity.src
@@ -2867,7 +2867,7 @@ cRo.ver=ver
 return cRo
 end function
 Menu.incAc=function
-if active_user!="root" then return 
+if active_user!="root" and package.Session!=0 then return 
 loc="/lib/aptclient.so"
 ac=include_lib(loc)
 if not ac then

--- a/unity.src
+++ b/unity.src
@@ -2869,7 +2869,7 @@ Menu = {}
         return cRo
         end function
     Menu.incAc = function
-        if active_user != "root" then return
+        if active_user != "root" and package.Session != 0 then return
         loc = "/lib/aptclient.so"
         ac = include_lib(loc)
         if not ac then


### PR DESCRIPTION
Fix for the runtime error in [Issue 1](https://github.com/MachaCeleste/CelestialCorp-Unity/issues/1). Add an exception in the `Menu.incAc` function for non-root users when `package.Session` is 0. allowing `Ac` to be assigned to `package.Depth[0]`.